### PR TITLE
Allow pilot targeting ID to be specified

### DIFF
--- a/mParticle-Apptimize/MPKitApptimize.h
+++ b/mParticle-Apptimize/MPKitApptimize.h
@@ -25,6 +25,15 @@
 
 @interface MPKitApptimize : NSObject <MPKitProtocol>
 
+/**
+ * Sets the pilot targeting ID for the Pilot Targeting API.
+ * If unspecifed then the user's identity string will be used.
+ * This method should be called before starting MParticle or as soon as the ID is known.
+ * https://apptimize.com/docs/featureflags/installation.html
+ * https://apptimize.com/docs/additional-features/pilot-users.html
+ */
++ (void)setPilotTargetingID:(NSString*) pilotTargetingID;
+
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;

--- a/mParticle-Apptimize/MPKitApptimize.h
+++ b/mParticle-Apptimize/MPKitApptimize.h
@@ -32,7 +32,7 @@
  * https://apptimize.com/docs/featureflags/installation.html
  * https://apptimize.com/docs/additional-features/pilot-users.html
  */
-+ (void)setPilotTargetingID:(NSString*) pilotTargetingID;
++ (void)setPilotTargetingID:(nonnull NSString *)pilotTargetingID;
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;

--- a/mParticle-Apptimize/MPKitApptimize.m
+++ b/mParticle-Apptimize/MPKitApptimize.m
@@ -55,7 +55,7 @@ static NSString *_pilotTargetingID = nil;
 
 #pragma mark - MPKitApptimize methods
 
-+ (void)setPilotTargetingID:(NSString*) pilotTargetingID {
++ (void)setPilotTargetingID:(nonnull NSString *)pilotTargetingID {
     void(^block)(void) = ^{
         _pilotTargetingID = pilotTargetingID;
         if ([[MParticle sharedInstance] isKitActive:[[self class] kitCode]]) {
@@ -72,7 +72,7 @@ static NSString *_pilotTargetingID = nil;
 #pragma mark - MPKitInstanceProtocol methods
 
 #pragma mark Kit instance and lifecycle
-- (MPKitExecStatus *)didFinishLaunchingWithConfiguration:(NSDictionary *)configuration {
+- (nonnull MPKitExecStatus *)didFinishLaunchingWithConfiguration:(nonnull NSDictionary *)configuration {
     MPKitExecStatus *execStatus = nil;
 
     NSString *appKey = configuration[APP_MP_KEY];


### PR DESCRIPTION
Hello!

We wanted to specify our own pilotTargetingID for Apptimize.

We needed to stop the `setUserIdentity` kit method from setting the pilotTargetingID when the identity changed.

After reading https://docs.mparticle.com/developers/sdk/ios/kits/ we took the approach of having a static method on MPApptimizeKit.

What do you think?

