### PR TITLE
fix: Header imports for mParticle SDK

### DIFF
--- a/mParticle-Apptimize.podspec
+++ b/mParticle-Apptimize.podspec
@@ -18,8 +18,4 @@ Pod::Spec.new do |s|
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.dependency 'Apptimize', '~> 3.2'
 
-    s.pod_target_xcconfig = {  'ARCHS' => '$(ARCHS_STANDARD_64_BIT)', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    s.user_target_xcconfig = {  'ARCHS' => '$(ARCHS_STANDARD_64_BIT)', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
-
 end

--- a/mParticle-Apptimize/MPKitApptimize.h
+++ b/mParticle-Apptimize/MPKitApptimize.h
@@ -1,8 +1,13 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 @interface MPKitApptimize : NSObject <MPKitProtocol>


### PR DESCRIPTION
## Summary
Adds headers for accessing public Swift classes in the core SDK. Marked as fix so semantic release will make a patch version bump instead of minor version bump.

## Testing Instructions
Tested by compiling and running a local app to see that there were no header or Swift related errors.